### PR TITLE
Handle transparent background when converting to jpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,16 @@ easier to use and build (no CloudFront whitelisting for example).
 If you don't like this approach you can use a CloudFront function to
 convert query parameters to path parameters.
 
-| Parameter   | Explanation                     | Example                | Default                                       |
-| ----------- | ------------------------------- | ---------------------- | --------------------------------------------- |
-| format      | `jpeg` or `webp` or `avif`      | `/avif`                | pick smallest `jpeg` or `webp` impage         |
-| dimensions  | `<width>x<height`>              | `/800x600`             | `320x200`                                     |
-| width only  | `<width>` or `<width>x`         | `/800`                 | height calculated to keep source aspect ratio |
-| height only | `x<height>`                     | `/x600`                | width calculated to keep source aspect ratio  |
-| focus point | `fp=<x>,<y>`                    | `/fp=2000,1200`        | (original_width / 2), (original_height / 3)   |
-| cropping    | `crop=<x>,<y>,<width>,<height>` | `/crop=96,0,3904,2850` | original image size                           |
-| quality     | `q=<0..100>`                    | `/q=80`                | automatic, depending on imagesize and format  |
+| Parameter   | Explanation                     | Example                | Default                                             |
+| ----------- | ------------------------------- | ---------------------- | --------------------------------------------------- |
+| format      | `jpeg` or `webp` or `avif`      | `/avif`                | pick smallest `jpeg` or `webp` impage               |
+| dimensions  | `<width>x<height`>              | `/800x600`             | `320x200`                                           |
+| width only  | `<width>` or `<width>x`         | `/800`                 | height calculated to keep source aspect ratio       |
+| height only | `x<height>`                     | `/x600`                | width calculated to keep source aspect ratio        |
+| focus point | `fp=<x>,<y>`                    | `/fp=2000,1200`        | (original_width / 2), (original_height / 3)         |
+| cropping    | `crop=<x>,<y>,<width>,<height>` | `/crop=96,0,3904,2850` | original image size                                 |
+| quality     | `q=<0..100>`                    | `/q=80`                | automatic, depending on imagesize and format        |
+| background  | `bg=<hex-rgb-color>`            | `/bg=ff0000`           | blend transparent pixels with this background color |
 
 Jpeg encoding uses `mozjpg` settings, so it has a similiar compression ratio as `webp` for photos.
 If you don't specify a format, the image optimizer will internally try

--- a/src/optimizeImage.ts
+++ b/src/optimizeImage.ts
@@ -13,7 +13,7 @@ type TransformParams = {
   focus?: Point
   crop?: Rectangle
   quality?: number
-  // background?: string // background color in (#ffffff) to blend alpha channel with
+  background?: string // background color to blend alpha channel with
 }
 
 export type OptimizingParams = Partial<TransformParams>
@@ -26,11 +26,16 @@ export const optimizeImage = async (image: Uint8Array, params: OptimizingParams)
   // and for low detail images (screenshots, diagrams, ...) webp produces smaller ones.
   // Because jpeg and webp are supported by all modern browsers, we can
   // pick the format that has the best compression, if no format was specified.
+  // For source images with format `png` or an alpha channel we always
+  // prefer webp for better image quality
+  const meta = await sharp(image).metadata()
+  if (meta.hasAlpha || ['png', 'gif', 'tif', 'tiff'].includes(meta.format ?? '')) {
+    return await transformImage(image, { ...params, format: 'webp' })
+  }
   const results = await Promise.all([
     transformImage(image, { ...params, format: 'webp' }),
-    transformImage(image, { ...params, format: 'jpeg' }).catch(() => undefined),
+    transformImage(image, { ...params, format: 'jpeg' }),
   ])
-  if (!results[1]) return results[0] // can't convert to jpeg, so let's hope that webp works
   return results[0].buffer.length < results[1].buffer.length ? results[0] : results[1]
 }
 
@@ -43,19 +48,18 @@ const transformImage = async (image: Uint8Array, params: TransformParams) => {
     height = params.width ? 0 : 200,
     focus = defaultFocus(size),
     crop = defaultCrop(size),
-    // background = params.format === 'jpeg', // for jpeg we need a default
+    background = params.format === 'jpeg' ? '#ffffff' : params.background, // for jpeg we need to always flatten
     format,
   } = params
-
-  // if (background) {
-  //   sharpImage.flatten({ background }) // TODO: shall we use the meta.background color from the image?
-  // }
 
   const ratio = width && height ? width / height : crop.width / crop.height
   const source = limitedRegion(focusCrop(ratio, focus, crop), size)
   const finalSize = limitedSize(width, height, ratio, source)
   const quality = params.quality || getQuality(format, finalSize)
 
+  if (background) {
+    sharpImage.flatten({ background })
+  }
   sharpImage.rotate() // normalize rotation
   sharpImage.extract(source)
   sharpImage.resize(finalSize)
@@ -73,8 +77,8 @@ export const getQuality = (format: ImageFormat, size: Size): number => {
     if (pixels < 800 * 800) return 50
     return 40
   } else if (format === 'avif') {
-    if (pixels < 400 * 400) return 50
-    if (pixels < 800 * 800) return 42
+    if (pixels < 400 * 400) return 55
+    if (pixels < 800 * 800) return 45
     return 35
   }
   throw Error(`automatic quality for format ${format} not implemented`)

--- a/src/parsePath.spec.ts
+++ b/src/parsePath.spec.ts
@@ -68,4 +68,10 @@ describe('parsePath', () => {
     expect(quality).toEqual(50)
     expect(error).toBeUndefined()
   })
+
+  it('should extract background parameter', () => {
+    const { background, error } = parsePath('/path/to/image/UUID/bg=ff0000/q=50')
+    expect(background).toEqual('#ff0000')
+    expect(error).toBeUndefined()
+  })
 })

--- a/src/parsePath.ts
+++ b/src/parsePath.ts
@@ -35,7 +35,8 @@ const parseSegment = (segment: string) =>
   parseDimensions(segment) ||
   parseFocusPoint(segment) ||
   parseCropRectangle(segment) ||
-  parseQuality(segment) || { error: `invalid segment "${segment}"` }
+  parseQuality(segment) ||
+  parseBackground(segment) || { error: `invalid segment "${segment}"` }
 
 const ignoreEmptySegment = (segment: string) => (!segment ? {} : undefined)
 
@@ -73,6 +74,12 @@ const parseQuality = (segment: string) => {
   const match = segment.match(/^q=(\d+)$/)
   if (!match) return undefined
   return { quality: parseInt(match[1]) }
+}
+
+const parseBackground = (segment: string) => {
+  const match = segment.match(/^bg=([0-9a-f]{6})$/)
+  if (!match) return undefined
+  return { background: `#${match[1]}` }
 }
 
 const parseInt = (value: string | undefined) => Number.parseInt(value!) // parseInt(undefined) will return NaN


### PR DESCRIPTION
Many image formats support transparent pixels (alpha channel).
But jpeg is a format that doesn't support transparency.
So if your desired format is 'jpeg' it's nice to blend transparent pixels with a given background color. 
You can specify the background in the usual hex rgb style, e.g. red is `/bg=ff0000`.

If you don't specify an format, the image optimizer will now automatically convert formats that have an alpha channel to `webp`. webp supports transparency and quality for lossless encoded images is better than in jpeg.